### PR TITLE
[임송이] global.css, Routes 생성, 기본 페이지 셋업, MainHeader component 생성

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,24 @@
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+
+import Layout from "./pages/Layout";
+import MyComparison from "./pages/MyComparison";
+import ComparisonStatus from "./pages/ComparisonStatus";
+import InvestmentStatus from "./pages/InvestmentStatus";
+import Home from "./pages/Home";
+
 function App() {
-  return;
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Layout />}>
+          <Route index element={<Home />} />
+          <Route path="my-comparison" element={<MyComparison />} />
+          <Route path="comparison-status" element={<ComparisonStatus />} />
+          <Route path="investment-status" element={<InvestmentStatus />} />
+        </Route>
+      </Routes>
+    </BrowserRouter>
+  );
 }
 
 export default App;

--- a/src/components/MainHeader/MainHeader.css
+++ b/src/components/MainHeader/MainHeader.css
@@ -28,7 +28,8 @@
   padding: 21px 17px;
 }
 
-@media only screen and (max-width: 1190px) {
+/*Tablet width 1199~744px*/
+@media only screen and (max-width: 1199px) {
   .MainHeader {
     height: 60px;
   }
@@ -38,6 +39,7 @@
   }
 }
 
+/*Mobile width 743px-375px*/
 @media only screen and (max-width: 743px) {
   .MainHeader {
     height: 56px;

--- a/src/components/MainHeader/MainHeader.css
+++ b/src/components/MainHeader/MainHeader.css
@@ -1,0 +1,59 @@
+.logo {
+  width: 112px;
+  height: auto;
+}
+
+.MainHeader {
+  display: flex;
+  justify-content: center;
+  border: 1px solid var(--black-100);
+  height: 70px;
+}
+
+.MainHeader .header-container {
+  display: flex;
+  max-width: 1200px;
+  width: 100%;
+  align-items: center;
+  gap: 40px;
+}
+
+.MainHeader nav ul {
+  display: flex;
+}
+
+.MainHeader nav li {
+  font-size: var(--15px);
+  font-weight: 600;
+  padding: 21px 17px;
+}
+
+@media only screen and (max-width: 1190px) {
+  .MainHeader {
+    height: 60px;
+  }
+  .MainHeader .header-container {
+    padding-left: 24px;
+    gap: 24px;
+  }
+}
+
+@media only screen and (max-width: 743px) {
+  .MainHeader {
+    height: 56px;
+  }
+  .MainHeader .header-container {
+    padding-left: 16px;
+    gap: 16px;
+  }
+  .MainHeader nav li {
+    padding: 19px 8px;
+    font-size: var(--13px);
+    font-weight: 700;
+  }
+  .logo {
+    max-width: 64px;
+    width: 100%;
+    height: auto;
+  }
+}

--- a/src/components/MainHeader/MainHeader.jsx
+++ b/src/components/MainHeader/MainHeader.jsx
@@ -1,0 +1,50 @@
+import { Link, NavLink } from "react-router-dom";
+
+import logoImg from "../../assets/logo_desktop.svg";
+
+import "./MainHeader.css";
+
+function getLinkStyle({ isActive }) {
+  return {
+    color: isActive ? "#fff" : "var(--grey-200)",
+  };
+}
+
+function Nav() {
+  return (
+    <nav>
+      <ul>
+        <li>
+          <NavLink to={"/my-comparison"} style={getLinkStyle}>
+            나의 기업 비교
+          </NavLink>
+        </li>
+        <li>
+          <NavLink to={"/comparison-status"} style={getLinkStyle}>
+            비교 현황
+          </NavLink>
+        </li>
+        <li>
+          <NavLink to={"/investment-status"} style={getLinkStyle}>
+            투자 현황
+          </NavLink>
+        </li>
+      </ul>
+    </nav>
+  );
+}
+
+export function MainHeader() {
+  return (
+    <header className="MainHeader">
+      <div className="header-container">
+        <Link to="/">
+          <img className="logo" src={logoImg} alt="view my startup logo" />
+        </Link>
+        <Nav />
+      </div>
+    </header>
+  );
+}
+
+export default MainHeader;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
-import ReactDOM from 'react-dom/client';
-import App from './App.jsx';
-import './global.css';
+import ReactDOM from "react-dom/client";
+import App from "./App.jsx";
+import "./utils/global.css";
 
-const root = ReactDOM.createRoot(document.getElementById('root'));
+const root = ReactDOM.createRoot(document.getElementById("root"));
 
 root.render(<App />);

--- a/src/pages/ComparisonStatus.jsx
+++ b/src/pages/ComparisonStatus.jsx
@@ -1,0 +1,5 @@
+function ComparisonStatus() {
+  return <h2>비교 현황</h2>;
+}
+
+export default ComparisonStatus;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,0 +1,5 @@
+function Home() {
+  return <h2>전체 스타트업 목록</h2>;
+}
+
+export default Home;

--- a/src/pages/InvestmentStatus.jsx
+++ b/src/pages/InvestmentStatus.jsx
@@ -1,0 +1,5 @@
+function InvestmentStatus() {
+  return <h2>투자 현황</h2>;
+}
+
+export default InvestmentStatus;

--- a/src/pages/Layout.css
+++ b/src/pages/Layout.css
@@ -1,0 +1,27 @@
+main {
+  color: #fff;
+  margin: 0 auto;
+  max-width: 1200px;
+  width: 100%;
+  padding: 40px 0;
+}
+
+main h2 {
+  font-size: var(--20px);
+  font-weight: 700;
+}
+
+@media only screen and (max-width: 1199px) {
+  main {
+    padding: 40px 24px;
+  }
+}
+
+@media only screen and (max-width: 743px) {
+  main {
+    padding: 24px 16px;
+  }
+  main h2 {
+    font-size: 1rem;
+  }
+}

--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -1,0 +1,18 @@
+import { Outlet } from "react-router-dom";
+
+import MainHeader from "../components/MainHeader/MainHeader.jsx";
+
+import "./Layout.css";
+
+function Layout() {
+  return (
+    <>
+      <MainHeader />
+      <main>
+        <Outlet />
+      </main>
+    </>
+  );
+}
+
+export default Layout;

--- a/src/pages/MyComparison.jsx
+++ b/src/pages/MyComparison.jsx
@@ -1,0 +1,5 @@
+function MyComparison() {
+  return <h2>나의 기업을 선택해 주세요!</h2>;
+}
+
+export default MyComparison;

--- a/src/utils/global.css
+++ b/src/utils/global.css
@@ -32,6 +32,7 @@
   /*  rem size variables */
 
   --12px: 0.75rem;
+  --13px: 0.8125rem;
   --14px: 0.875rem;
   --15px: 0.9375rem;
   --18px: 1.125rem;
@@ -123,8 +124,10 @@ button {
 }
 
 body {
-  font-family: 'Pretendard Variable', Pretendard, -apple-system,
-    BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue', 'Segoe UI',
-    'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', 'Apple Color Emoji',
-    'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
+  font-family: "Pretendard Variable", Pretendard, -apple-system,
+    BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI",
+    "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji",
+    "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
+
+  background-color: var(--black-400);
 }

--- a/src/utils/global.css
+++ b/src/utils/global.css
@@ -1,0 +1,130 @@
+*,
+*::before,
+*::after {
+  margin: 0em;
+  padding: 0em;
+  font-size: 100%;
+  border-style: none;
+  list-style-type: none;
+  text-decoration: none;
+  box-sizing: border-box;
+  font: inherit;
+  line-height: 1.5;
+}
+
+:root {
+  /* color variables */
+
+  --orange: #eb5230;
+  --red: #c41013;
+  --blue: #558fff;
+
+  --black-400: #131313;
+  --black-300: #212121;
+  --black-200: #282828;
+  --black-100: #2e2e2e;
+
+  --grey-400: #333333;
+  --grey-300: #4b4b4b;
+  --grey-200: #747474;
+  --grey-100: #d8d8d8;
+
+  /*  rem size variables */
+
+  --12px: 0.75rem;
+  --14px: 0.875rem;
+  --15px: 0.9375rem;
+  --18px: 1.125rem;
+  --20px: 1.25rem;
+  --24px: 1.5rem;
+  --40px: 2.5rem;
+}
+
+html {
+  overflow-wrap: break-word;
+  word-break: keep-all;
+  -webkit-tap-highlight-color: transparent;
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+  cursor: default;
+  line-height: 1.5;
+  -moz-tab-size: 4;
+  tab-size: 4;
+}
+
+img,
+picture,
+video,
+canvas,
+svg {
+  display: block;
+  max-width: 100%;
+}
+
+a {
+  text-decoration: none;
+  cursor: pointer;
+}
+
+a:not([class]) {
+  text-decoration-skip-ink: auto;
+  color: currentColor;
+}
+
+h1,
+h2,
+h3,
+h4 {
+  text-wrap: balance;
+  margin-block-end: 0;
+}
+
+body,
+p,
+figure,
+blockquote,
+dl,
+dd {
+  margin-block-end: 0;
+}
+
+input,
+button,
+textarea,
+select {
+  font: inherit;
+  background: none;
+  border: 0;
+  cursor: pointer;
+}
+
+textarea:not([rows]) {
+  min-height: 10em;
+}
+
+:target {
+  scroll-margin-block: 5ex;
+}
+
+input:focus,
+textarea:focus {
+  outline: 1px solid var(--blue);
+}
+
+::placeholder {
+  font-size: var(--14px);
+  font-weight: 400;
+  color: var(--grey-200);
+}
+
+button {
+  background-color: var(--orange);
+  color: #fff;
+}
+
+body {
+  font-family: 'Pretendard Variable', Pretendard, -apple-system,
+    BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue', 'Segoe UI',
+    'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
+}


### PR DESCRIPTION

## components 구조.
![Screenshot 2024-08-13 at 11 00 46 PM](https://github.com/user-attachments/assets/7b3a512d-b0a8-4e11-bc47-80b406dae173)

### global.css
- 브랜드 컬러 팔렛트
- 폰트사이즈 (rem으로 변환된 px)
- 기본 버튼 색
- 폰트
- 기본 placeholder

### Routes
일단 네비게이션 바에 있는 links 4개만 라우트 체크위해 page 컴포넌트로 만들어습니다.

Routes:
' / ' = Home (기업전체 리스트)
'/my-comparison' = 나의 기업 비교 
'/comparison-status' = 비교 현황
'/investment-status' = 투자 현황

### Layout
/pages/Layout.jsx 에서 <main> 하위 부분이 outlet되는 구조입니다.

### MainHeader component
desktop, table, mobile responsive design 적용.
`<main>` 도 responsive하게 top과 양쪽 padding이 생깁니다.

