### PR TITLE
공통 페이지네이션 컴포넌트

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "proxy": "http://localhost:3000"
+  }
 }

--- a/src/components/Pagination/Pagination.css
+++ b/src/components/Pagination/Pagination.css
@@ -2,14 +2,43 @@
   display: flex;
   align-self: center;
   margin-top: 40px;
+  gap: 4px;
+}
+
+.Pagination li:first-of-type {
+  margin-right: 4px;
+}
+
+.Pagination li:last-of-type {
+  margin-left: 4px;
 }
 
 .Pagination button {
   display: flex;
   justify-content: center;
   align-items: center;
+  font-size: var(--18px);
   background-color: var(--black-100);
   width: 48px;
   height: 48px;
   border-radius: 10px;
+  color: var(--grey-200);
+}
+
+.Pagination .active {
+  background-color: var(--orange);
+  color: #fff;
+}
+
+.Pagination button:disabled {
+  cursor: not-allowed;
+  opacity: 0.3;
+}
+
+@media only screen and (max-width: 743px) {
+  .Pagination button {
+    font-size: 1rem;
+    width: 32px;
+    height: 32px;
+  }
 }

--- a/src/components/Pagination/Pagination.jsx
+++ b/src/components/Pagination/Pagination.jsx
@@ -1,31 +1,76 @@
-// import { useState } from "react";
-// import prevBtnIcon from "../../assets/icon/ic_arrow_left.svg";
-// import nextBtnIcon from "../../assets/icon/ic_arrow_right.svg";
+import prevBtnIcon from "../../assets/icon/ic_arrow_left.svg";
+import nextBtnIcon from "../../assets/icon/ic_arrow_right.svg";
 
-// import "./Pagination.css";
+import "./Pagination.css";
 
-// export function Pagination({ cursor, setCursor, nextCursor }) {
+// page, setPage를 currentPage, setCurrentPage로 내려줌
+export function Pagination({ currentPage, setCurrentPage, totalPages }) {
+  let pageNumbers = [];
 
-//   return (
-//     <ol className="Pagination">
-//       <li>
-//         <button>
-//           <img src={prevBtnIcon} alt="left button" />
-//         </button>
-//       </li>
-//       {pageNumbers.map((pageNum) => {
-//         return (
-//           <li key={pageNum}>
-//             <button onClick={(pageNum) => handlePageClick}>{pageNum}</button>
-//           </li>
-//         );
-//       })}
-//       <li>
-//         <button>
-//           {" "}
-//           <img src={nextBtnIcon} alt="right button" />{" "}
-//         </button>
-//       </li>
-//     </ol>
-//   );
-// }
+  let startPage;
+  let endPage;
+
+  //totalPages가 5개 이하 아닌이상 항상 5개 버튼 보여주도록 함
+  // currentPage가 3이상일때 부터 중앙정렬
+  if (currentPage < 3) {
+    startPage = 1;
+    //totalPages가 5보다 아래면 totalPages가 끝번호
+    endPage = Math.min(totalPages, 5);
+  } else if (currentPage >= totalPages - 2) {
+    startPage = totalPages - 4;
+    endPage = totalPages;
+    //기본 currentPage 중앙정렬
+  } else {
+    startPage = currentPage - 2;
+    endPage = Math.min(currentPage + 2, totalPages);
+  }
+
+  //항상 startPage 1이상이고 , endPage는 totalPages 이하도록
+  startPage = Math.max(1, startPage);
+  endPage = Math.min(totalPages, endPage);
+
+  for (let i = startPage; i <= endPage; i++) {
+    pageNumbers.push(i);
+  }
+
+  const handlePageClick = (pageNum) => {
+    setCurrentPage(pageNum);
+  };
+  //이전 버튼 -1씩 이동
+  const prevBtnClick = () => {
+    setCurrentPage((prevPage) => prevPage - 1);
+  };
+
+  // 다음 버튼 +1씩 이동
+  const nextBtnClick = () => {
+    setCurrentPage((prevPage) => prevPage + 1);
+  };
+  return (
+    <ul className="Pagination">
+      <li>
+        <button onClick={prevBtnClick} disabled={currentPage <= 1}>
+          <img src={prevBtnIcon} alt="left button" />
+        </button>
+      </li>
+      {pageNumbers.map((pageNum) => {
+        //현재 페이지 버튼에 isActive = true로 'active' className 부여해 스타일링
+        const isActive = pageNum === currentPage;
+        return (
+          <li key={pageNum}>
+            <button
+              onClick={() => handlePageClick(pageNum)}
+              className={isActive ? "active" : ""}
+            >
+              {pageNum}
+            </button>
+          </li>
+        );
+      })}
+      <li>
+        <button onClick={nextBtnClick} disabled={currentPage >= totalPages}>
+          <img src={nextBtnIcon} alt="right button" />
+        </button>
+      </li>
+    </ul>
+  );
+}

--- a/src/pages/ComparisonStatus.jsx
+++ b/src/pages/ComparisonStatus.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { getSelectionStatus } from "../services/companyApi";
 import { Table } from "../components/Table/Table";
 import { DropDown } from "../components/DropDown/DropDown";
+import { Pagination } from "../components/Pagination/Pagination";
 
 import { comparisonStatusTableHeader } from "../utils/tableTypes";
 import "./Home.css";
@@ -9,16 +10,18 @@ import "./Home.css";
 function ComparisonStatus() {
   const [orderBy, setOrderBy] = useState("selectedCount_desc");
   const [companyList, setCompanyList] = useState([]);
-  const [cursor, setCursor] = useState("");
-  const [nextCursor, setNextCursor] = useState(null);
+  const [page, setPage] = useState(1);
+  const [limit, setLimit] = useState(10);
+  const [totalPages, setTotalPages] = useState(0);
 
   const init = useCallback(async () => {
     try {
-      const data = await getSelectionStatus({ orderBy, cursor });
+      const data = await getSelectionStatus({ orderBy, page, limit });
 
-      const { list, nextCursor } = data;
+      const { list, totalCount } = data;
       setCompanyList(list);
-      setNextCursor(nextCursor || null);
+      //totalPages = 전체 페이지 버튼 수
+      setTotalPages(Math.ceil(totalCount / limit));
     } catch (err) {
       console.error(err.message);
 
@@ -27,7 +30,7 @@ function ComparisonStatus() {
         console.log(err.response.data);
       }
     }
-  }, [orderBy, cursor]);
+  }, [orderBy, page, limit]);
 
   useEffect(() => {
     init();
@@ -44,6 +47,11 @@ function ComparisonStatus() {
         />
       </div>
       <Table list={companyList} tableHeaders={comparisonStatusTableHeader} />
+      <Pagination
+        currentPage={page}
+        setCurrentPage={setPage}
+        totalPages={totalPages}
+      />
     </section>
   );
 }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { getCompanies } from "../services/companyApi";
 import { Table } from "../components/Table/Table";
 import { DropDown } from "../components/DropDown/DropDown";
+import { Pagination } from "../components/Pagination/Pagination";
 
 import { companyListTableHeader } from "../utils/tableTypes";
 
@@ -10,17 +11,18 @@ import "./Home.css";
 function Home() {
   const [orderBy, setOrderBy] = useState("revenue_desc");
   const [companyList, setCompanyList] = useState([]);
-  const [keyword, setKeyword] = useState("");
-  const [cursor, setCursor] = useState("");
-  const [nextCursor, setNextCursor] = useState(null);
+  const [page, setPage] = useState(1);
+  const [limit, setLimit] = useState(10);
+  const [totalPages, setTotalPages] = useState(0);
 
   const init = useCallback(async () => {
     try {
-      const data = await getCompanies({ orderBy, cursor });
+      const data = await getCompanies({ orderBy, page, limit });
 
-      const { list, nextCursor } = data;
+      const { list, totalCount } = data;
       setCompanyList(list);
-      setNextCursor(nextCursor || null);
+      //totalPages = 전체 페이지 버튼 수
+      setTotalPages(Math.ceil(totalCount / limit));
     } catch (err) {
       console.error(err.message);
 
@@ -29,7 +31,7 @@ function Home() {
         console.log(err.response.data);
       }
     }
-  }, [orderBy, cursor]);
+  }, [orderBy, page, limit]);
 
   useEffect(() => {
     init();
@@ -49,6 +51,11 @@ function Home() {
         list={companyList}
         tableHeaders={companyListTableHeader}
         tableName="company-list"
+      />
+      <Pagination
+        currentPage={page}
+        setCurrentPage={setPage}
+        totalPages={totalPages}
       />
     </section>
   );

--- a/src/pages/InvestmentStatus.jsx
+++ b/src/pages/InvestmentStatus.jsx
@@ -2,23 +2,25 @@ import { useState, useEffect, useCallback } from "react";
 import { getInvestmentStatus } from "../services/companyApi";
 import { Table } from "../components/Table/Table";
 import { DropDown } from "../components/DropDown/DropDown";
+import { Pagination } from "../components/Pagination/Pagination";
 
-import "./Home.css";
 import { InvestmentStatusTableHeader } from "../utils/tableTypes";
+import "./Home.css";
 
 function InvestmentStatus() {
   const [orderBy, setOrderBy] = useState("virtualInvestment_desc");
   const [companyList, setCompanyList] = useState([]);
-  const [cursor, setCursor] = useState("");
-  const [nextCursor, setNextCursor] = useState(null);
+  const [page, setPage] = useState(1);
+  const [limit, setLimit] = useState(10);
+  const [totalPages, setTotalPages] = useState(0);
 
   const init = useCallback(async () => {
     try {
-      const data = await getInvestmentStatus({ orderBy, cursor });
+      const data = await getInvestmentStatus({ orderBy, page, limit });
 
-      const { list, nextCursor } = data;
+      const { list, totalCount } = data;
       setCompanyList(list);
-      setNextCursor(nextCursor || null);
+      setTotalPages(Math.ceil(totalCount / limit));
     } catch (err) {
       console.error(err.message);
 
@@ -27,7 +29,7 @@ function InvestmentStatus() {
         console.log(err.response.data);
       }
     }
-  }, [orderBy, cursor]);
+  }, [orderBy, limit, page]);
 
   useEffect(() => {
     init();
@@ -44,6 +46,12 @@ function InvestmentStatus() {
         />
       </div>
       <Table list={companyList} tableHeaders={InvestmentStatusTableHeader} />
+
+      <Pagination
+        currentPage={page}
+        setCurrentPage={setPage}
+        totalPages={totalPages}
+      />
     </section>
   );
 }

--- a/src/services/companyApi.js
+++ b/src/services/companyApi.js
@@ -16,12 +16,12 @@ export async function getCompanies({
   limit = 10,
   orderBy = "revenue_desc",
   keyword = "",
-  nextCursor,
+  page = 1,
 }) {
   const { sortBy, order } = splitSortOption(orderBy);
   try {
     const res = await instance.get("/api/companies", {
-      params: { nextCursor, limit, sortBy, order, keyword },
+      params: { page, limit, sortBy, order, keyword },
     });
     return res.data;
   } catch (error) {
@@ -32,12 +32,12 @@ export async function getCompanies({
 export async function getInvestmentStatus({
   limit = 10,
   orderBy = "virtualInvestment_desc",
-  nextCursor,
+  page = 1,
 }) {
   const { sortBy, order } = splitSortOption(orderBy);
   try {
     const res = await instance.get("/api/companies/investments/status", {
-      params: { nextCursor, limit, sortBy, order },
+      params: { page, limit, sortBy, order },
     });
     return res.data;
   } catch (error) {
@@ -48,12 +48,12 @@ export async function getInvestmentStatus({
 export async function getSelectionStatus({
   limit = 10,
   orderBy = "selectedCount_desc",
-  nextCursor,
+  page = 1,
 }) {
   const { sortBy, order } = splitSortOption(orderBy);
   try {
     const res = await instance.get("/api/comparisons/selections", {
-      params: { nextCursor, limit, sortBy, order },
+      params: { page, limit, sortBy, order },
     });
     return res.data;
   } catch (error) {


### PR DESCRIPTION
### 공통 페이지네이션 컴포넌트

- totalCount로 totalPages (총 버튼갯수 = 페이지갯수)설정
- totalPages가 5개 이상일땐 항상 버튼 5개씩 display
- 현재 페이지가 중앙으로 오게 정렬
- 현재 페이지가 1,2 와 마지막 -1,-2일땐 처음과 끝은 나타내기 위해 중앙정렬하지 않음.
- responsive css까지 완성.
- 현재페이지가 처음과 마지막 페이지일때 이전, 다음버튼 비활성화
- 현재페이지 버튼은 주황색 배경

-필요한 props: totalPages, currentPage, setCurrentPage
*page와 setPage를 currentPage, setCurrentPage이름으로 내려줌.

```
 <Pagination
        currentPage={page}
        setCurrentPage={setPage}
        totalPages={totalPages}
      />
```

![Screenshot 2024-08-19 at 5 21 57 PM](https://github.com/user-attachments/assets/a7005b33-332a-4020-88ae-98902b3b537f)


개선사항 발견하시면 피드백 부탁드려요! 

