### PR TITLE
Pagination 무한 api 호출

### DIFF
--- a/src/components/Pagination/Pagination.jsx
+++ b/src/components/Pagination/Pagination.jsx
@@ -1,12 +1,13 @@
+import { useCallback } from "react";
 import prevBtnIcon from "../../assets/icon/ic_arrow_left.svg";
 import nextBtnIcon from "../../assets/icon/ic_arrow_right.svg";
 
 import "./Pagination.css";
 
 // page, setPage를 currentPage, setCurrentPage로 내려줌
-export function Pagination({ setCurrentPage, queryParams, size }) {
+export function Pagination({ setCurrentPage, queryParams, totalPages, size }) {
   //page이름 currentPage로 re-assign
-  const { page: currentPage, totalPages } = queryParams;
+  const { page: currentPage } = queryParams;
 
   let pageNumbers = [];
 
@@ -36,19 +37,30 @@ export function Pagination({ setCurrentPage, queryParams, size }) {
     pageNumbers.push(i);
   }
 
-  const handlePageClick = (pageNum) => {
-    setCurrentPage("page", pageNum);
-  };
+  //각 함수에 useCallback 추가함 (렌더링시 의존 배열이 바뀌지 않았다면 함수 재랜덩 방지)
+  const handlePageClick = useCallback(
+    (pageNum) => {
+      if (pageNum !== currentPage) {
+        setCurrentPage("page", pageNum);
+      }
+    },
+    [setCurrentPage, currentPage]
+  );
 
   //이전 버튼 -1씩 이동
-  const prevBtnClick = () => {
-    setCurrentPage("page", currentPage - 1);
-  };
+  const prevBtnClick = useCallback(() => {
+    if (currentPage > 1) {
+      setCurrentPage({ page: currentPage - 1 });
+    }
+  }, [setCurrentPage, currentPage]);
 
   // 다음 버튼 +1씩 이동
-  const nextBtnClick = () => {
-    setCurrentPage("page", currentPage + 1);
-  };
+  const nextBtnClick = useCallback(() => {
+    if (currentPage < totalPages) {
+      setCurrentPage("page", currentPage + 1);
+    }
+  }, [setCurrentPage, currentPage, totalPages]);
+
   return (
     <ul className={`Pagination ${size}`}>
       <li>

--- a/src/components/Pagination/Pagination.jsx
+++ b/src/components/Pagination/Pagination.jsx
@@ -5,9 +5,9 @@ import nextBtnIcon from "../../assets/icon/ic_arrow_right.svg";
 import "./Pagination.css";
 
 // page, setPage를 currentPage, setCurrentPage로 내려줌
-export function Pagination({ setCurrentPage, queryParams, totalPages, size }) {
+export function Pagination({ setCurrentPage, queryParams, size }) {
   //page이름 currentPage로 re-assign
-  const { page: currentPage } = queryParams;
+  const { page: currentPage, totalPages } = queryParams;
 
   let pageNumbers = [];
 

--- a/src/components/Table/Table.css
+++ b/src/components/Table/Table.css
@@ -31,7 +31,7 @@
   border-bottom-left-radius: 4px;
 }
 
-.Table thead tr th:first-of-type {
+.Table thead tr th:last-of-type {
   border-bottom-right-radius: 4px;
 }
 

--- a/src/pages/ComparisonStatus.jsx
+++ b/src/pages/ComparisonStatus.jsx
@@ -11,13 +11,13 @@ import "./Home.css";
 const INITIAL_QUERY_PARAMS = {
   orderBy: "selectedCount_desc",
   limit: 10,
-  totalPages: 0,
   page: 1,
 };
 
 function ComparisonStatus() {
   const [companyList, setCompanyList] = useState([]);
   const [queryParams, setQueryParams] = useState(INITIAL_QUERY_PARAMS);
+  const [totalPages, setTotalPages] = useState(0);
 
   //쿼리 파라미터 한번에 객체로 관리
   // 쿼리 파라미터 핸들러 (name = query name, value= query value)
@@ -37,7 +37,7 @@ function ComparisonStatus() {
 
       const { list, totalCount } = data;
       setCompanyList(list);
-      handleQueryParamsChange("totalPages", Math.ceil(totalCount / limit));
+      setTotalPages(Math.ceil(totalCount / limit));
     } catch (err) {
       console.error(err.message);
 
@@ -66,6 +66,7 @@ function ComparisonStatus() {
       <Pagination
         setCurrentPage={handleQueryParamsChange}
         queryParams={queryParams}
+        totalPages={totalPages}
       />
     </section>
   );

--- a/src/pages/ComparisonStatus.jsx
+++ b/src/pages/ComparisonStatus.jsx
@@ -12,12 +12,12 @@ const INITIAL_QUERY_PARAMS = {
   orderBy: "selectedCount_desc",
   limit: 10,
   page: 1,
+  totalPages: 0,
 };
 
 function ComparisonStatus() {
   const [companyList, setCompanyList] = useState([]);
   const [queryParams, setQueryParams] = useState(INITIAL_QUERY_PARAMS);
-  const [totalPages, setTotalPages] = useState(0);
 
   //쿼리 파라미터 한번에 객체로 관리
   // 쿼리 파라미터 핸들러 (name = query name, value= query value)
@@ -37,7 +37,10 @@ function ComparisonStatus() {
 
       const { list, totalCount } = data;
       setCompanyList(list);
-      setTotalPages(Math.ceil(totalCount / limit));
+      const newTotalPages = Math.ceil(totalCount / limit);
+      if (queryParams.totalPages !== newTotalPages) {
+        handleQueryParamsChange("totalPages", newTotalPages);
+      }
     } catch (err) {
       console.error(err.message);
 
@@ -66,7 +69,6 @@ function ComparisonStatus() {
       <Pagination
         setCurrentPage={handleQueryParamsChange}
         queryParams={queryParams}
-        totalPages={totalPages}
       />
     </section>
   );

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -14,7 +14,6 @@ import "./Home.css";
 const INITIAL_QUERY_PARAMS = {
   orderBy: "revenue_desc",
   limit: 10,
-  totalPages: 0,
   page: 1,
   keyword: "",
 };
@@ -22,6 +21,7 @@ const INITIAL_QUERY_PARAMS = {
 function Home() {
   const [companyList, setCompanyList] = useState([]);
   const [queryParams, setQueryParams] = useState(INITIAL_QUERY_PARAMS);
+  const [totalPages, setTotalPages] = useState(0);
 
   //쿼리 파라미터 한번에 객체로 관리
   // 쿼리 파라미터 핸들러 (name = query name, value= query value)
@@ -42,10 +42,7 @@ function Home() {
 
         const { list, totalCount } = data;
         setCompanyList(list);
-        const newTotalPages = Math.ceil(totalCount / limit);
-        if (newTotalPages !== queryParams.totalPages) {
-          handleQueryParamsChange("totalPages", newTotalPages);
-        }
+        setTotalPages(Math.ceil(totalCount / limit));
       } catch (err) {
         console.error(err.message);
 
@@ -69,7 +66,6 @@ function Home() {
     <section className="Home">
       <div className="top-bar">
         <h2 className="top-bar-title">전체 스타트업 목록</h2>
-
         <SearchBar setKeyword={handleQueryParamsChange} />
         <DropDown
           orderBy={queryParams.orderBy}
@@ -84,6 +80,7 @@ function Home() {
       />
       <Pagination
         setCurrentPage={handleQueryParamsChange}
+        totalPages={totalPages}
         queryParams={queryParams}
       />
     </section>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -16,14 +16,14 @@ const INITIAL_QUERY_PARAMS = {
   limit: 10,
   page: 1,
   keyword: "",
+  totalPages: 0,
 };
 
 function Home() {
   const [companyList, setCompanyList] = useState([]);
   const [queryParams, setQueryParams] = useState(INITIAL_QUERY_PARAMS);
-  const [totalPages, setTotalPages] = useState(0);
 
-  //쿼리 파라미터 한번에 객체로 관리
+  //쿼리 파라미터 한번에 객체로 관리s
   // 쿼리 파라미터 핸들러 (name = query name, value= query value)
   const handleQueryParamsChange = (name, value) => {
     setQueryParams((preValue) => {
@@ -34,33 +34,32 @@ function Home() {
     });
   };
 
-  useEffect(() => {
-    const init = async () => {
-      const { orderBy, page, limit, keyword } = queryParams;
-      try {
-        const data = await getCompanies({ orderBy, page, limit, keyword });
+  const init = useCallback(async () => {
+    const { orderBy, page, limit, keyword } = queryParams;
+    try {
+      const data = await getCompanies({ orderBy, page, limit, keyword });
 
-        const { list, totalCount } = data;
-        setCompanyList(list);
-        setTotalPages(Math.ceil(totalCount / limit));
-      } catch (err) {
-        console.error(err.message);
-
-        if (err.response) {
-          console.log(err.response.status);
-          console.log(err.response.data);
-        }
+      const { list, totalCount } = data;
+      setCompanyList(list);
+      const newTotalPages = Math.ceil(totalCount / limit);
+      if (queryParams.totalPages !== newTotalPages) {
+        handleQueryParamsChange("totalPages", newTotalPages);
       }
-    };
+    } catch (err) {
+      console.error(err.message);
 
-    init();
+      if (err.response) {
+        console.log(err.response.status);
+        console.log(err.response.data);
+      }
+    }
   }, [queryParams]); // queryParams가 변경될 때만 init 함수가 실행되도록 설정
 
   // // 컴포넌트가 처음 렌더링될 때,
   // // 그리고 init 함수가 변결될 때 실행
-  // useEffect(() => {
-  //   init();
-  // }, [init]);
+  useEffect(() => {
+    init();
+  }, [init]);
 
   return (
     <section className="Home">
@@ -80,7 +79,6 @@ function Home() {
       />
       <Pagination
         setCurrentPage={handleQueryParamsChange}
-        totalPages={totalPages}
         queryParams={queryParams}
       />
     </section>

--- a/src/pages/InvestmentStatus.jsx
+++ b/src/pages/InvestmentStatus.jsx
@@ -11,13 +11,13 @@ import "./Home.css";
 const INITIAL_QUERY_PARAMS = {
   orderBy: "virtualInvestment_desc",
   limit: 10,
-  totalPages: 0,
   page: 1,
 };
 
 function InvestmentStatus() {
   const [companyList, setCompanyList] = useState([]);
   const [queryParams, setQueryParams] = useState(INITIAL_QUERY_PARAMS);
+  const [totalPages, setTotalPages] = useState(0);
 
   //쿼리 파라미터 한번에 객체로 관리
   // 쿼리 파라미터 핸들러 (name = query name, value= query value)
@@ -37,7 +37,7 @@ function InvestmentStatus() {
 
       const { list, totalCount } = data;
       setCompanyList(list);
-      handleQueryParamsChange("totalPages", Math.ceil(totalCount / limit));
+      setTotalPages(Math.ceil(totalCount / limit));
     } catch (err) {
       console.error(err.message);
 
@@ -67,6 +67,7 @@ function InvestmentStatus() {
       <Pagination
         setCurrentPage={handleQueryParamsChange}
         queryParams={queryParams}
+        totalPages={totalPages}
       />
     </section>
   );

--- a/src/pages/InvestmentStatus.jsx
+++ b/src/pages/InvestmentStatus.jsx
@@ -12,12 +12,12 @@ const INITIAL_QUERY_PARAMS = {
   orderBy: "virtualInvestment_desc",
   limit: 10,
   page: 1,
+  totalPages: 0,
 };
 
 function InvestmentStatus() {
   const [companyList, setCompanyList] = useState([]);
   const [queryParams, setQueryParams] = useState(INITIAL_QUERY_PARAMS);
-  const [totalPages, setTotalPages] = useState(0);
 
   //쿼리 파라미터 한번에 객체로 관리
   // 쿼리 파라미터 핸들러 (name = query name, value= query value)
@@ -37,7 +37,10 @@ function InvestmentStatus() {
 
       const { list, totalCount } = data;
       setCompanyList(list);
-      setTotalPages(Math.ceil(totalCount / limit));
+      const newTotalPages = Math.ceil(totalCount / limit);
+      if (queryParams.totalPages !== newTotalPages) {
+        handleQueryParamsChange("totalPages", newTotalPages);
+      }
     } catch (err) {
       console.error(err.message);
 
@@ -67,7 +70,6 @@ function InvestmentStatus() {
       <Pagination
         setCurrentPage={handleQueryParamsChange}
         queryParams={queryParams}
-        totalPages={totalPages}
       />
     </section>
   );

--- a/src/utils/buttonOptions.js
+++ b/src/utils/buttonOptions.js
@@ -16,7 +16,7 @@ const typeTwoOptions = [
   { value: "selectedCount_desc", label: "나의 기업 선택 횟수 높은순" },
   { value: "selectedCount_asc", label: "나의 기업 선택 횟수 낮은순" },
   { value: "comparedCount_desc", label: "비교 기업 선택 횟수 높은순" },
-  { value: "comparedCount_asc", label: "비교 기업 선택 횟수 높은순" },
+  { value: "comparedCount_asc", label: "비교 기업 선택 횟수 낮은순" },
 ];
 
 //?sortBy=virtualInvestment?order=desc


### PR DESCRIPTION
- 테이블 헤더 css border-radius 수정
- pagination 함수에 useCallback 추가 (자주쓰이는 컴포넌트라 불필요한 재렌덩 방지)

pagination api 무한 호출 상훈님 방식으로 고쳤어요.
api 호출 함수에 조건문 추가했습니다. 해보니 어차피 totalCount나 totalPages 둘중에 하나는 prop으로 내려줘야 하기때문에
그냥 totalPages 따로 state로 빼는것보다 기존에서 상훈님이 하신것처럼 조건문 해주는게 좋을거 같아요!
필요하다면 나중에 더 개선 시키면 좋을것 같습니다!

```
const newTotalPages = Math.ceil(totalCount / limit);
      if (queryParams.totalPages !== newTotalPages) {
        handleQueryParamsChange("totalPages", newTotalPages);
      }
```

결론 : 페이지네이션 props는 요대로 쓰시되, 데스크탑사이즈에서도 버튼이 작아야 한다면 size="small" 내려주면 된다!
```
 <Pagination
        setCurrentPage={handleQueryParamsChange}
        queryParams={queryParams}
      />
```