### PR TITLE
[탁우현] 비교 페이지 성능 개선

### DIFF
--- a/src/components/CreateInvestment/CreateInvestment.jsx
+++ b/src/components/CreateInvestment/CreateInvestment.jsx
@@ -28,6 +28,7 @@ function CreateInvestment({ isOpen = false, myCompany, onClose }) {
     password: "password",
     passwordConfirm: "password",
   });
+  const [error, setError] = useState({});
 
   const handelOpenAlert = () => setAlertMeg(true);
   const handelCloseAlert = () => setAlertMeg(false);
@@ -43,6 +44,20 @@ function CreateInvestment({ isOpen = false, myCompany, onClose }) {
     event.preventDefault();
     const { name, value } = event.target;
     handleChangeValues(name, value);
+  };
+
+  const validationPassword = (e) => {
+    if (investmentValues.password !== e.target.value) {
+      setError((prev) => ({
+        ...prev,
+        [e.target.name]: e.target.value,
+      }));
+    } else {
+      setError((prev) => ({
+        ...prev,
+        [e.target.name]: "",
+      }));
+    }
   };
 
   const handleClose = (e) => {
@@ -160,7 +175,7 @@ function CreateInvestment({ isOpen = false, myCompany, onClose }) {
               <input
                 name="passwordConfirm"
                 type={inputTypes.passwordConfirm}
-                // onChange={onChange}
+                onChange={validationPassword}
                 className="modal-input"
                 placeholder="비밀번호를 다시 한 번 입력해 주세요"
                 autoComplete="new-password"
@@ -172,6 +187,9 @@ function CreateInvestment({ isOpen = false, myCompany, onClose }) {
                 <img src={ic_eyes} alt="비밀번호 보기" />
               </button>
             </div>
+            {error.passwordConfirm && (
+              <p style={{ color: "orange" }}>비밀번호가 일치하지 않습니다.</p>
+            )}
             <div className="modal-btn-container">
               <button onClick={handleClose} className="modal-close-btn">
                 취소

--- a/src/components/SelectComparisonCompany/SelectComparisonCompany.jsx
+++ b/src/components/SelectComparisonCompany/SelectComparisonCompany.jsx
@@ -114,6 +114,7 @@ function SelectComparisonCompany({
   };
 
   const handleSearch = async () => {
+    if (!isOpen) return;
     try {
       const { list, totalCount = 0 } = await getCompanies(queryObj);
       setCompanies(list);
@@ -130,11 +131,12 @@ function SelectComparisonCompany({
   //모달 다이얼로그 Ref 관리 -> 모달 open상태와 API호루 쿼리의 의존성 부여
   useEffect(() => {
     isOpen ? dialogRef.current.showModal() : dialogRef.current.close();
-  }, [isOpen]);
-
-  useEffect(() => {
     handleSearch();
-  }, [queryObj]);
+  }, [isOpen, queryObj]);
+
+  // useEffect(() => {
+  //   handleSearch();
+  // }, [queryObj]);
 
   return (
     <dialog ref={dialogRef} className="modal-company">

--- a/src/components/SelectMyCompany/SelectMyCompany.jsx
+++ b/src/components/SelectMyCompany/SelectMyCompany.jsx
@@ -80,6 +80,7 @@ function SelectMyCompany({
   const handleKeywordSearch = (event) => handleSubmit(event);
 
   const handleSearch = async () => {
+    if (!isOpen) return;
     try {
       const { list, totalCount = 0 } = await getCompanies(queryObj);
       setCompanies(list);
@@ -96,11 +97,12 @@ function SelectMyCompany({
   //모달 다이얼로그 Ref 관리 -> 모달 open상태와 API호루 쿼리의 의존성 부여
   useEffect(() => {
     isOpen ? dialogRef.current.showModal() : dialogRef.current.close();
-  }, [isOpen]);
-
-  useEffect(() => {
     handleSearch();
-  }, [queryObj]);
+  }, [isOpen, queryObj]);
+
+  // useEffect(() => {
+  //   handleSearch();
+  // }, [queryObj]);
 
   return (
     <dialog ref={dialogRef} className="modal-company">

--- a/src/pages/CheckInComparison.jsx
+++ b/src/pages/CheckInComparison.jsx
@@ -74,27 +74,30 @@ function CheckInComparison() {
   const handelCloseCreateModal = () => setCreateModal(false);
 
   //API호출
-  const loadComparisonData = async () => {
+  const allLoadComparisonData = async () => {
     try {
-      const data = await api.getComparison(comparisonParams, reqComparison);
-      setComparisonItem(data);
-    } catch (error) {
-      console.log(error.message);
-    }
-  };
+      const comparisonPromise = api.getComparison(
+        comparisonParams,
+        reqComparison
+      );
+      const comparisonRankPromise = api.getComparisonRank(
+        rankParams,
+        myCompany.id
+      );
 
-  const loadComparisonRankData = async () => {
-    try {
-      const data = await api.getComparisonRank(rankParams, myCompany.id);
-      setComparisonRankItem(data);
+      const [comparisonData, comparisonRankData] = await Promise.all([
+        comparisonPromise,
+        comparisonRankPromise,
+      ]);
+      setComparisonItem(comparisonData);
+      setComparisonRankItem(comparisonRankData);
     } catch (error) {
       console.log(error.message);
     }
   };
 
   useEffect(() => {
-    loadComparisonData();
-    loadComparisonRankData();
+    allLoadComparisonData();
   }, [comparisonParams, rankParams]);
 
   return (


### PR DESCRIPTION
1.비교결과 페이지의 API 호출을 두 번 하는 부분을 동시에 요청 후 한 번에 기다리는 방식으로 변경

2.나의 기업의 투자 부분 유효성 검사 추가

3.비교페이지의 모달이 오픈되지 않아도 API 요청을 하는 부분을 모달이 오픈 되었을 때 요청하는 방식으로 변경