### PR TITLE
[박상훈] 데이터 새로고침을 위한 window.location.reload 대신 version 상태 사용

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,27 +11,22 @@ import { InvestmentProvider } from "./contexts/InvestmentContext";
 
 function App() {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Layout />}>
-          <Route index element={<Home />} />
-          <Route path="my-comparison">
-            <Route index element={<MyComparison />} />
-            <Route path="check-id-comparison" element={<CheckInComparison />} />
+    <InvestmentProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<Layout />}>
+            <Route index element={<Home />} />
+            <Route path="my-comparison">
+              <Route index element={<MyComparison />} />
+              <Route path="check-id-comparison" element={<CheckInComparison />} />
+            </Route>
+            <Route path="comparison-status" element={<ComparisonStatus />} />
+            <Route path="investment-status" element={<InvestmentStatus />} />
+            <Route path="companies/:companyId" element={<CompanyDetail />} />
           </Route>
-          <Route path="comparison-status" element={<ComparisonStatus />} />
-          <Route path="investment-status" element={<InvestmentStatus />} />
-          <Route
-            path="companies/:companyId"
-            element={
-              <InvestmentProvider>
-                <CompanyDetail />
-              </InvestmentProvider>
-            }
-          />
-        </Route>
-      </Routes>
-    </BrowserRouter>
+        </Routes>
+      </BrowserRouter>
+    </InvestmentProvider>
   );
 }
 

--- a/src/components/DropDown/DetailPageDropdown.jsx
+++ b/src/components/DropDown/DetailPageDropdown.jsx
@@ -57,7 +57,8 @@ function DetailPageDropdown({ id, password, amount, comment }) {
     if (previousModal === "delete") {
       setIsDeleteModalOpen(true); // 삭제 모달을 다시 열기
     } else if (previousModal === "updateConfirm") {
-      setIsUpdateConfirmModalOpen(true); // 업데이트 모달을 다시 열기
+      setIsUpdateConfirmModalOpen(false); // 업데이트 모달을 다시 열기
+      setIsUpdateModalOpen(false);
     }
   };
 

--- a/src/contexts/InvestmentContext.jsx
+++ b/src/contexts/InvestmentContext.jsx
@@ -6,15 +6,18 @@ export const InvestmentContext = createContext();
 
 export function InvestmentProvider({ children }) {
   const [investments, setInvestments] = useState([]);
+  const [version, setVersion] = useState(0);
 
   const loadInvestments = useCallback((newInvestments) => {
     setInvestments(newInvestments);
+    setVersion((preVersion) => preVersion + 1);
   }, []);
 
   const addInvestment = async (investmentData) => {
     try {
       const newInvestment = await createInvestment(investmentData);
       setInvestments((prevInvestments) => [...prevInvestments, newInvestment]);
+      setVersion((preVersion) => preVersion + 1);
     } catch (error) {
       console.error("Failed to create investment:", error);
     }
@@ -26,6 +29,7 @@ export function InvestmentProvider({ children }) {
       setInvestments((prevInvestments) =>
         prevInvestments.map((investment) => (investment.id === id ? updatedInvestment : investment))
       );
+      setVersion((preVersion) => preVersion + 1);
     } catch (error) {
       console.error("Failed to update investment:", error);
     }
@@ -35,7 +39,7 @@ export function InvestmentProvider({ children }) {
     try {
       await deleteInvestment({ id, password });
       setInvestments((prevInvestments) => prevInvestments.filter((investment) => investment.id !== id));
-      console.log(`Investment with id: ${id} deleted successfully`);
+      setVersion((preVersion) => preVersion + 1);
     } catch (error) {
       console.error("Failed to delete investment:", error);
     }
@@ -43,7 +47,15 @@ export function InvestmentProvider({ children }) {
 
   return (
     <InvestmentContext.Provider
-      value={{ investments, loadInvestments, updateInvestmentById, deleteInvestmentById, addInvestment }}
+      value={{
+        investments,
+        loadInvestments,
+        updateInvestmentById,
+        deleteInvestmentById,
+        addInvestment,
+        version,
+        setVersion,
+      }}
     >
       {children}
     </InvestmentContext.Provider>

--- a/src/pages/CompanyDetail.jsx
+++ b/src/pages/CompanyDetail.jsx
@@ -32,7 +32,7 @@ function CompanyDetail() {
   const [queryParams, setQueryParams] = useState(INITIAL_QUERY_PARAMS);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
-  const { loadInvestments } = useContext(InvestmentContext);
+  const { loadInvestments, version } = useContext(InvestmentContext);
 
   //쿼리 파라미터 한번에 객체로 관리
   // 쿼리 파라미터 핸들러 (name = query name, value= query value)
@@ -80,16 +80,16 @@ function CompanyDetail() {
 
     // 컴포넌트가 마운트되면 데이터 가져오기 시작
     fetchCompany();
-  }, [companyId, queryParams.page, queryParams.limit, loadInvestments]);
-
-  if (loading) return <Loader />; // 로딩 중일 때 메시지 표시
-  if (error) return <ErrorMsg errorMsg={error} />; // 에러 발생 시 메시지 표시
-  if (!companyData) return <div>No company data available</div>; // company가 null일 경우 처리
+  }, [companyId, queryParams.page, queryParams.limit, loadInvestments, version]);
 
   // 상세페이지에 필요한 정보
   const { id, name, brandColor, categoryNames, categories, actual, revenue, employees, description, investments } =
     companyData;
   const selectedCompany = { id, name, categories, brandColor };
+
+  if (loading) return <Loader />; // 로딩 중일 때 메시지 표시
+  if (error) return <ErrorMsg errorMsg={error} />; // 에러 발생 시 메시지 표시
+  if (!companyData) return <div>No company data available</div>; // company가 null일 경우 처리
 
   return (
     <div className="CompanyDetail">


### PR DESCRIPTION
-  투자 생성 및 삭제 후 window.location.reload() 사용 제거
- InvestmentContext의 version 상태를 활용하여 데이터 새로고침 구현
- 성공적인 투자 및 삭제 후 전체 페이지 리로드 없이 동적으로 페이지가 업데이트되도록 구현
- 불필요한 전체 페이지 리로드를 피함으로써 성능 개선